### PR TITLE
fix: NamedShaped derivation logic

### DIFF
--- a/packages/core/src/traits/shaped.ts
+++ b/packages/core/src/traits/shaped.ts
@@ -1,5 +1,5 @@
-import { Shape, type DictShorthand, type Shorthand } from "@ddd-ts/shape";
-import { Derive, Trait } from "@ddd-ts/traits";
+import { Shape, type DictShorthand } from "@ddd-ts/shape";
+import { Trait, WithDerivations } from "@ddd-ts/traits";
 import { Named } from "./named";
 
 export const Shaped = <S extends DictShorthand>(shape: S) =>
@@ -8,4 +8,4 @@ export const Shaped = <S extends DictShorthand>(shape: S) =>
 export const NamedShaped = <const Name extends string, S extends DictShorthand>(
   name: Name,
   shape: S,
-) => Trait((base) => Derive(Named(name), Shaped({ ...shape, name })));
+) => Trait((base) => WithDerivations(base, Named(name), Shaped({ ...shape, name })));


### PR DESCRIPTION
There seems to have a bug in `NamedShaped` implementation 
The base class is not extended properly


## How to reproduce
```typescript
// BUGGY
export class MyQueryBug extends WithDerivations(
  Query<NamedDownloadableFile>,
  NamedShaped("Buggy", {
    userId: UserId,
  }),
) {}

console.log("KO ------> instance", new MyQueryBug({
  userId: UserId.from("00000000000000000000"),
  name: "Buggy",
}).type);

console.log("KO ------> static", MyQueryBug.type);

// WORKING
export class MyWorkingQuery extends WithDerivations(
  Query<NamedDownloadableFile>,
  Named("Working"),
  Shaped({
    userId: UserId,
  }),
) {}

console.log("OK ------> instance", new MyWorkingQuery({
  userId: UserId.from("00000000000000000000"),
  name: "DownloadDirectoryQuery",
}).type);

console.log("OK ------> static", MyWorkingQuery.type);
```

### Results

```
KO ------> instance
KO ------> static
OK ------> instance MyWorkingQuery
OK ------> static MyWorkingQuery
```