### PR TITLE
fix(projection): :bug: resolve tied-cursor stuck state in FirestorePr…

### DIFF
--- a/packages/core/src/components/cursor.spec.ts
+++ b/packages/core/src/components/cursor.spec.ts
@@ -1,0 +1,61 @@
+import { MicrosecondTimestamp } from "@ddd-ts/shape";
+import { Cursor } from "./cursor";
+import { EventId } from "./event-id";
+
+const realCursor = (overrides: Partial<{ ref: string; micros: bigint; revision: number; eventId: string }> = {}) =>
+  new Cursor({
+    ref: overrides.ref ?? "event-store/Account/streams/abc/events/1",
+    occurredAt: new MicrosecondTimestamp(overrides.micros ?? BigInt(1_000_000_000_000_000)),
+    revision: overrides.revision ?? 1,
+    eventId: new EventId(overrides.eventId ?? "evt-1"),
+  });
+
+describe("Cursor sentinels", () => {
+  it("MIN is never after a real cursor", () => {
+    const c = realCursor();
+    expect(Cursor.MIN.isAfter(c)).toBe(false);
+  });
+
+  it("a real cursor is always after MIN", () => {
+    const c = realCursor();
+    expect(c.isAfter(Cursor.MIN)).toBe(true);
+  });
+
+  it("MAX is always after a real cursor", () => {
+    const c = realCursor();
+    expect(Cursor.MAX.isAfter(c)).toBe(true);
+  });
+
+  it("a real cursor is never after MAX", () => {
+    const c = realCursor();
+    expect(c.isAfter(Cursor.MAX)).toBe(false);
+  });
+
+  it("MAX is after MIN", () => {
+    expect(Cursor.MAX.isAfter(Cursor.MIN)).toBe(true);
+    expect(Cursor.MIN.isAfter(Cursor.MAX)).toBe(false);
+  });
+
+  it("MIN is not after MIN; MAX is not after MAX", () => {
+    expect(Cursor.MIN.isAfter(Cursor.MIN)).toBe(false);
+    expect(Cursor.MAX.isAfter(Cursor.MAX)).toBe(false);
+  });
+
+  it("identifies sentinels", () => {
+    expect(Cursor.MIN.isMin()).toBe(true);
+    expect(Cursor.MAX.isMax()).toBe(true);
+    expect(Cursor.MIN.isSentinel()).toBe(true);
+    expect(Cursor.MAX.isSentinel()).toBe(true);
+
+    const c = realCursor();
+    expect(c.isMin()).toBe(false);
+    expect(c.isMax()).toBe(false);
+    expect(c.isSentinel()).toBe(false);
+  });
+
+  it("isOlderThan: MIN is older than any timestamp; MAX is never older", () => {
+    const ts = MicrosecondTimestamp.now();
+    expect(Cursor.MIN.isOlderThan(ts)).toBe(true);
+    expect(Cursor.MAX.isOlderThan(ts)).toBe(false);
+  });
+});

--- a/packages/core/src/components/cursor.ts
+++ b/packages/core/src/components/cursor.ts
@@ -29,6 +29,12 @@ export class Cursor extends Shape({
       return false;
     }
 
+    if (typeof this.ref !== "string" || typeof other.ref !== "string") {
+      throw new Error(
+        `Cursor.isAfter: ref must be a string, got ${typeof this.ref} vs ${typeof other.ref}`,
+      );
+    }
+
     return this.ref > other.ref;
   }
 

--- a/packages/core/src/components/cursor.ts
+++ b/packages/core/src/components/cursor.ts
@@ -2,13 +2,44 @@ import { MicrosecondTimestamp, Shape } from "@ddd-ts/shape";
 import { EventId } from "./event-id";
 import type { IFact } from "../interfaces/es-event";
 
+export const CURSOR_MIN_REF = "<MIN>";
+export const CURSOR_MAX_REF = "<MAX>";
+
 export class Cursor extends Shape({
   ref: String,
   occurredAt: MicrosecondTimestamp,
   revision: Number,
   eventId: EventId,
 }) {
-  isAfter(other: Cursor) {
+  static MIN: Cursor;
+  static MAX: Cursor;
+
+  isMin() {
+    return this.ref === CURSOR_MIN_REF;
+  }
+
+  isMax() {
+    return this.ref === CURSOR_MAX_REF;
+  }
+
+  isSentinel() {
+    return this.isMin() || this.isMax();
+  }
+
+  isAfter(other: Cursor): boolean {
+    if (this.isMax()) {
+      return !other.isMax();
+    }
+    if (other.isMax()) {
+      return false;
+    }
+    if (this.isMin()) {
+      return false;
+    }
+    if (other.isMin()) {
+      return true;
+    }
+
     if (this.is(other)) {
       return false;
     }
@@ -43,6 +74,12 @@ export class Cursor extends Shape({
   }
 
   isOlderThan(microsecondTimestamp: MicrosecondTimestamp) {
+    if (this.isMin()) {
+      return true;
+    }
+    if (this.isMax()) {
+      return false;
+    }
     return this.occurredAt.isBefore(microsecondTimestamp);
   }
 
@@ -59,3 +96,19 @@ export class Cursor extends Shape({
     return `${this.ref}`;
   }
 }
+
+Cursor.MIN = new Cursor({
+  ref: CURSOR_MIN_REF,
+  occurredAt: new MicrosecondTimestamp(BigInt(0)),
+  revision: -1,
+  eventId: new EventId(""),
+});
+
+Cursor.MAX = new Cursor({
+  ref: CURSOR_MAX_REF,
+  occurredAt: new MicrosecondTimestamp(
+    BigInt(253402300799999) * BigInt(1000), // 9999-12-31T23:59:59.999Z in micros
+  ),
+  revision: -1,
+  eventId: new EventId(""),
+});

--- a/packages/core/src/components/projected-stream.ts
+++ b/packages/core/src/components/projected-stream.ts
@@ -1,4 +1,4 @@
-import { Either, Multiple, Shape } from "@ddd-ts/shape";
+import { Either, MicrosecondTimestamp, Multiple, Shape } from "@ddd-ts/shape";
 import type {
   IEsEvent,
   IFact,
@@ -49,6 +49,25 @@ export interface ProjectedStreamStorageLayer {
     endAt?: Cursor,
     count?: number,
   ): Promise<ISerializedFact[]>;
+
+  /**
+   * Returns the first fact at or after `from` (microsecond timestamp), or
+   * undefined if no event matches. Implementations should query with `>=`,
+   * not `>`, so the boundary fact is included.
+   */
+  firstAtOrAfter?(
+    projectedStream: ProjectedStream,
+    shard: string,
+    from: MicrosecondTimestamp,
+  ): Promise<ISerializedFact | undefined>;
+
+  /**
+   * Returns the most recent fact in the stream, or undefined if empty.
+   */
+  latest?(
+    projectedStream: ProjectedStream,
+    shard: string,
+  ): Promise<ISerializedFact | undefined>;
 }
 
 export class ProjectedStreamReader<Event extends IEsEvent> {
@@ -101,5 +120,42 @@ export class ProjectedStreamReader<Event extends IEsEvent> {
     return (await Promise.all(
       slice.map((fact) => this.registry.deserialize(fact)),
     )) as IFact<Event>[];
+  }
+
+  async first(
+    source: ProjectedStream,
+    shard: string,
+  ): Promise<IFact<Event> | undefined> {
+    const [fact] = await this.slice(source, shard, Cursor.MIN, Cursor.MAX, 1);
+    return fact;
+  }
+
+  async firstAtOrAfter(
+    source: ProjectedStream,
+    shard: string,
+    from: MicrosecondTimestamp,
+  ): Promise<IFact<Event> | undefined> {
+    if (!this.reader.firstAtOrAfter) {
+      throw new Error(
+        "Underlying ProjectedStreamStorageLayer does not implement firstAtOrAfter",
+      );
+    }
+    const fact = await this.reader.firstAtOrAfter(source, shard, from);
+    if (!fact) return undefined;
+    return this.registry.deserialize(fact) as IFact<Event>;
+  }
+
+  async latest(
+    source: ProjectedStream,
+    shard: string,
+  ): Promise<IFact<Event> | undefined> {
+    if (!this.reader.latest) {
+      throw new Error(
+        "Underlying ProjectedStreamStorageLayer does not implement latest",
+      );
+    }
+    const fact = await this.reader.latest(source, shard);
+    if (!fact) return undefined;
+    return this.registry.deserialize(fact) as IFact<Event>;
   }
 }

--- a/packages/core/src/components/serializer-registry.ts
+++ b/packages/core/src/components/serializer-registry.ts
@@ -1,4 +1,5 @@
 import type { HasTrait } from "@ddd-ts/traits";
+import { DeserializationError } from "@ddd-ts/shape";
 import type { INamed, INamedContructor } from "../interfaces/named";
 import type {
   ISerializer,
@@ -155,7 +156,31 @@ export class SerializerRegistry<
       throw new Error(`No serializer for ${name}`);
     }
 
-    return serializer.deserialize(serialized);
+    const version =
+      typeof serialized === "object" &&
+      serialized !== null &&
+      "version" in serialized &&
+      typeof (serialized as any).version === "number"
+        ? (serialized as any).version
+        : undefined;
+
+    try {
+      const result = serializer.deserialize(serialized);
+      if (result && typeof (result as any).then === "function") {
+        return (result as Promise<unknown>).catch((err) => {
+          if (err instanceof DeserializationError) {
+            err.registryEntry ??= { name, version };
+          }
+          throw err;
+        });
+      }
+      return result;
+    } catch (err) {
+      if (err instanceof DeserializationError) {
+        err.registryEntry ??= { name, version };
+      }
+      throw err;
+    }
   }
 }
 

--- a/packages/core/src/projections/projection.ts
+++ b/packages/core/src/projections/projection.ts
@@ -30,7 +30,7 @@ export abstract class ESProjection<E extends IEsEvent, C = any> {
     this.handlers[event.$name] = handler as IESProjectionHandler<E, C>;
   }
 
-  abstract getSource(event: E): ProjectedStream;
+  abstract getSource(event?: E): ProjectedStream;
   abstract getCheckpointId(event: E): CheckpointId;
 
   getHandler<T extends E>(event: T) {

--- a/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
+++ b/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
@@ -203,4 +203,85 @@ export class FirestoreProjectedStreamStorageLayer
       } as ISerializedFact;
     });
   }
+
+  async firstAtOrAfter(
+    projectedStream: ProjectedStream,
+    shard: string,
+    from: MicrosecondTimestamp,
+  ): Promise<ISerializedFact | undefined> {
+    const ts = this.microsecondToTimestamp(from);
+    let query = this.firestore
+      .collectionGroup("events")
+      .orderBy("occurredAt")
+      .orderBy("revision")
+      .orderBy(FieldPath.documentId())
+      .startAt(ts)
+      .limit(1);
+
+    const filters = projectedStream.sources.map((source) => {
+      if (source instanceof LakeSource) {
+        return new FirestoreLakeSourceFilter().filter(shard, source);
+      }
+      if (source instanceof StreamSource) {
+        return new FirestoreStreamSourceFilter().filter(shard, source);
+      }
+      throw new Error("Unknown source type");
+    });
+
+    query = query.where(Filter.or(...filters));
+
+    const snap = await query.get();
+    const doc = snap.docs[0];
+    if (!doc) return undefined;
+    const data = this.converter.fromFirestore(doc);
+    return {
+      id: data.eventId,
+      ref: doc.ref.path,
+      revision: data.revision,
+      name: data.name,
+      $name: data.name,
+      payload: data.payload,
+      occurredAt: data.occurredAt,
+      version: data.version ?? 1,
+    } as ISerializedFact;
+  }
+
+  async latest(
+    projectedStream: ProjectedStream,
+    shard: string,
+  ): Promise<ISerializedFact | undefined> {
+    let query = this.firestore
+      .collectionGroup("events")
+      .orderBy("occurredAt", "desc")
+      .orderBy("revision", "desc")
+      .orderBy(FieldPath.documentId(), "desc")
+      .limit(1);
+
+    const filters = projectedStream.sources.map((source) => {
+      if (source instanceof LakeSource) {
+        return new FirestoreLakeSourceFilter().filter(shard, source);
+      }
+      if (source instanceof StreamSource) {
+        return new FirestoreStreamSourceFilter().filter(shard, source);
+      }
+      throw new Error("Unknown source type");
+    });
+
+    query = query.where(Filter.or(...filters));
+
+    const snap = await query.get();
+    const doc = snap.docs[0];
+    if (!doc) return undefined;
+    const data = this.converter.fromFirestore(doc);
+    return {
+      id: data.eventId,
+      ref: doc.ref.path,
+      revision: data.revision,
+      name: data.name,
+      $name: data.name,
+      payload: data.payload,
+      occurredAt: data.occurredAt,
+      version: data.version ?? 1,
+    } as ISerializedFact;
+  }
 }

--- a/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
+++ b/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
@@ -68,7 +68,7 @@ export class FirestoreProjectedStreamStorageLayer
 
     query = query.where(Filter.or(...filters));
 
-    if (startAfter) {
+    if (startAfter && !startAfter.isMin()) {
       const ts = this.microsecondToTimestamp(startAfter.occurredAt);
       query = query.startAfter(
         ts,
@@ -77,7 +77,7 @@ export class FirestoreProjectedStreamStorageLayer
       );
     }
 
-    if (endAt) {
+    if (endAt && !endAt.isMax()) {
       const ts = this.microsecondToTimestamp(endAt.occurredAt);
       query = query.endAt(
         ts,
@@ -165,7 +165,7 @@ export class FirestoreProjectedStreamStorageLayer
 
     query = query.where(Filter.or(...filters));
 
-    if (startAfter) {
+    if (startAfter && !startAfter.isMin()) {
       const ts = this.microsecondToTimestamp(startAfter.occurredAt);
       query = query.startAfter(
         ts,
@@ -174,7 +174,7 @@ export class FirestoreProjectedStreamStorageLayer
       );
     }
 
-    if (endAt) {
+    if (endAt && !endAt.isMax()) {
       const ts = this.microsecondToTimestamp(endAt.occurredAt);
       query = query.endAt(
         ts,

--- a/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
+++ b/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
@@ -214,9 +214,7 @@ export class FirestoreProjectedStreamStorageLayer
       .collectionGroup("events")
       .orderBy("occurredAt")
       .orderBy("revision")
-      .orderBy(FieldPath.documentId())
-      .startAt(ts)
-      .limit(1);
+      .orderBy(FieldPath.documentId());
 
     const filters = projectedStream.sources.map((source) => {
       if (source instanceof LakeSource) {
@@ -228,7 +226,7 @@ export class FirestoreProjectedStreamStorageLayer
       throw new Error("Unknown source type");
     });
 
-    query = query.where(Filter.or(...filters));
+    query = query.where(Filter.or(...filters)).startAt(ts).limit(1);
 
     const snap = await query.get();
     const doc = snap.docs[0];

--- a/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
+++ b/packages/event-sourcing-firestore/src/firestore.projected-stream.storage-layer.ts
@@ -8,6 +8,7 @@ import {
 } from "@ddd-ts/core";
 import { DefaultConverter } from "@ddd-ts/store-firestore";
 import {
+  FieldPath,
   Filter,
   Firestore,
   QueryDocumentSnapshot,
@@ -52,7 +53,8 @@ export class FirestoreProjectedStreamStorageLayer
     let query = this.firestore
       .collectionGroup("events")
       .orderBy("occurredAt")
-      .orderBy("revision");
+      .orderBy("revision")
+      .orderBy(FieldPath.documentId());
 
     const filters = projectedStream.sources.map((source) => {
       if (source instanceof LakeSource) {
@@ -68,12 +70,20 @@ export class FirestoreProjectedStreamStorageLayer
 
     if (startAfter) {
       const ts = this.microsecondToTimestamp(startAfter.occurredAt);
-      query = query.startAfter(ts, startAfter.revision);
+      query = query.startAfter(
+        ts,
+        startAfter.revision,
+        this.firestore.doc(startAfter.ref),
+      );
     }
 
     if (endAt) {
       const ts = this.microsecondToTimestamp(endAt.occurredAt);
-      query = query.endAt(ts, endAt.revision);
+      query = query.endAt(
+        ts,
+        endAt.revision,
+        this.firestore.doc(endAt.ref),
+      );
     }
 
     for await (const doc of query.stream() as AsyncIterable<QueryDocumentSnapshot>) {
@@ -140,7 +150,8 @@ export class FirestoreProjectedStreamStorageLayer
     let query = this.firestore
       .collectionGroup("events")
       .orderBy("occurredAt")
-      .orderBy("revision");
+      .orderBy("revision")
+      .orderBy(FieldPath.documentId());
 
     const filters = projectedStream.sources.map((source) => {
       if (source instanceof LakeSource) {
@@ -156,12 +167,20 @@ export class FirestoreProjectedStreamStorageLayer
 
     if (startAfter) {
       const ts = this.microsecondToTimestamp(startAfter.occurredAt);
-      query = query.startAfter(ts, startAfter.revision);
+      query = query.startAfter(
+        ts,
+        startAfter.revision,
+        this.firestore.doc(startAfter.ref),
+      );
     }
 
     if (endAt) {
       const ts = this.microsecondToTimestamp(endAt.occurredAt);
-      query = query.endAt(ts, endAt.revision);
+      query = query.endAt(
+        ts,
+        endAt.revision,
+        this.firestore.doc(endAt.ref),
+      );
     }
 
     if (limit) {

--- a/packages/event-sourcing-firestore/src/projection/cases/replay-api.spec.ts
+++ b/packages/event-sourcing-firestore/src/projection/cases/replay-api.spec.ts
@@ -1,0 +1,136 @@
+import { Cursor } from "@ddd-ts/core";
+import { CheckpointId } from "@ddd-ts/core";
+import { caseFixture, locks, traits } from "../testkit/case-fixture";
+import { FirestoreQueueStore } from "../firestore.projector";
+
+jest.setTimeout(120_000);
+
+const test = caseFixture("ReplayApi", {
+  handlers: {
+    Deposited: {
+      chain: [
+        traits.Context(),
+        traits.Transaction(),
+        traits.Suspense(),
+        traits.Parallel(),
+      ],
+      lock: locks.accountAndEventId,
+    },
+  },
+  projector: {
+    retry: { attempts: 5, minDelay: 50, maxDelay: 50 },
+    enqueue: { batchSize: 50 },
+  },
+});
+
+test.describe(() => {
+  it("catchup() enqueues + drains to completion", async () => {
+    const { events, act, projector, projection, queueStore, assert } =
+      await test.setup();
+
+    const [account, opened] = events.open(`${test.name}-catchup`);
+    await act.save(account);
+    account.deposit(10);
+    account.deposit(20);
+    account.deposit(30);
+    await act.save(account);
+
+    const checkpointId = projection.getCheckpointId(opened);
+
+    // Don't call handle(); use catchup() to drive replay end-to-end.
+    await projector.catchup(checkpointId, { deadlineMs: 30_000 });
+
+    expect(await queueStore.hasUnprocessed(checkpointId)).toBe(false);
+    await assert.cashflow(account.id).toHave({
+      id: account.id,
+      flow: 60,
+    });
+  });
+
+  it("play() wipes queue and replays from the beginning", async () => {
+    const { events, act, projector, projection, queueStore, cashflowStore, assert } =
+      await test.setup();
+
+    const [account, opened] = events.open(`${test.name}-play`);
+    await act.save(account);
+    account.deposit(5);
+    account.deposit(7);
+    await act.save(account);
+
+    const checkpointId = projection.getCheckpointId(opened);
+
+    // Bring the projection up to date once.
+    await projector.catchup(checkpointId, { deadlineMs: 30_000 });
+    await assert.cashflow(account.id).toHave({ flow: 12 });
+
+    // Reset projection state — play() only resets the queue, callers
+    // are responsible for wiping read-model state before replay.
+    await (cashflowStore as any).delete(account.id);
+
+    // Replay from scratch — should converge to the same state.
+    await projector.play(checkpointId);
+    expect(await queueStore.hasUnprocessed(checkpointId)).toBe(false);
+    await assert.cashflow(account.id).toHave({ flow: 12 });
+  });
+
+  it("flush({except}) preserves the blocker", async () => {
+    const { events, act, projection, queueStore } = await test.setup();
+    const [account, opened] = events.open(`${test.name}-flush-except`);
+    await act.save(account);
+    account.deposit(1);
+    await act.save(account);
+
+    const checkpointId = projection.getCheckpointId(opened);
+
+    await queueStore.block(checkpointId);
+    await queueStore.flush(checkpointId, {
+      except: [FirestoreQueueStore.BLOCKER_EVENT_ID],
+    });
+
+    const blockerDoc = await queueStore
+      .queued(checkpointId, FirestoreQueueStore.BLOCKER_EVENT_ID)
+      .get();
+    expect(blockerDoc.exists).toBe(true);
+
+    await queueStore.unblock(checkpointId);
+    const afterUnblock = await queueStore
+      .queued(checkpointId, FirestoreQueueStore.BLOCKER_EVENT_ID)
+      .get();
+    expect(afterUnblock.exists).toBe(false);
+  });
+
+  it("enqueueCursor({ idempotent }) is safe to re-trigger", async () => {
+    const { events, act, projector, projection } = await test.setup();
+    const [account, opened] = events.open(`${test.name}-idempotent-enqueue`);
+    await act.save(account);
+    account.deposit(1);
+    await act.save(account);
+
+    const checkpointId = projection.getCheckpointId(opened);
+    const fact = await projector.reader.first(
+      projection.getSource(),
+      checkpointId.shard(),
+    );
+    if (!fact) throw new Error("expected a fact");
+    const cursor = Cursor.from(fact);
+
+    await projector.enqueueCursor(checkpointId, cursor, { idempotent: true });
+    // Re-triggering should not throw ALREADY_EXISTS.
+    await projector.enqueueCursor(checkpointId, cursor, { idempotent: true });
+  });
+
+  it("shouldHandle gates handle() without enqueueing", async () => {
+    const { events, act, projection, queueStore, projector } =
+      await test.setup();
+
+    projector.config.shouldHandle = async () => false;
+
+    const [account, opened] = events.open(`${test.name}-should-handle`);
+    await act.save(account);
+
+    await projector.handle(opened);
+
+    const checkpointId = projection.getCheckpointId(opened);
+    expect(await queueStore.hasUnprocessed(checkpointId)).toBe(false);
+  });
+});

--- a/packages/event-sourcing-firestore/src/projection/cases/tiedcursor.spec.ts
+++ b/packages/event-sourcing-firestore/src/projection/cases/tiedcursor.spec.ts
@@ -1,0 +1,75 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { caseFixture, locks, traits } from "../testkit/case-fixture";
+
+jest.setTimeout(120_000);
+
+const test = caseFixture("TiedCursor", {
+  handlers: {
+    Deposited: {
+      chain: [
+        traits.Context(),
+        traits.Transaction(),
+        traits.Suspense(),
+        traits.Parallel(),
+      ],
+      lock: locks.accountAndEventId,
+    },
+  },
+  projector: {
+    retry: { attempts: 5, minDelay: 50, maxDelay: 50 },
+    enqueue: { batchSize: 50 },
+  },
+});
+
+test.describe(() => {
+  it("converges when events share (occurredAt, revision)", async () => {
+    const { db, events, act, accountStore, assert } = await test.setup();
+
+    const [account, opened] = events.open(test.name);
+    await act.save(account);
+
+    // Process opened first so the cashflow doc exists.
+    await act.handle(opened);
+
+    const deposits = [
+      account.deposit(1),
+      account.deposit(2),
+      account.deposit(3),
+      account.deposit(4),
+      account.deposit(5),
+    ];
+    await act.save(account);
+
+    // Force ties: all deposits get the same (occurredAt, revision) and that
+    // tie group occurs strictly after opened. This mimics a bulk import where
+    // the producer assigns timestamps at a coarser granularity than
+    // Firestore's microsecond storage.
+    const tiedAt = Timestamp.fromMillis(Date.now() + 60_000);
+    const tiedRevision = 99;
+    const collection = db
+      .collection("event-store")
+      .doc("Account")
+      .collection("streams")
+      .doc(account.id.serialize())
+      .collection("events");
+
+    await Promise.all(
+      deposits.map(async (d) => {
+        await collection.doc(`${(d as any).revision}`).update({
+          occurredAt: tiedAt,
+          revision: tiedRevision,
+        });
+      }),
+    );
+
+    // Now call handle() on each. The projector's queue/head/slice logic
+    // must cope with the tie group without losing or duplicating tasks.
+    await act.handle(opened);
+    await Promise.all(deposits.map((d) => act.handle(d)));
+
+    await assert.cashflow(account.id).toHave({
+      id: account.id,
+      flow: account.balance,
+    });
+  });
+});

--- a/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
+++ b/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
@@ -73,6 +73,12 @@ interface FirestoreProjectorConfig {
    *   each successful event handling.
    */
   cleanup?: false | { olderThan: MicrosecondTimestamp };
+  /**
+   * Optional pre-handle filter. Returning `false` causes `handle()` to
+   * return without enqueuing or processing the event. Useful for feature
+   * flags or per-shard gating without subclassing the projector.
+   */
+  shouldHandle?: (event: ISavedChange<IEsEvent>) => Promise<boolean> | boolean;
   logger?: ProjectorLogger;
   /** @deprecated Use `logger.error` instead */
   onProcessError: (error: Error) => void;
@@ -153,6 +159,11 @@ export class FirestoreProjector {
   }
 
   async handle(savedChange: ISavedChange<IEsEvent>) {
+    if (this.config.shouldHandle) {
+      const accept = await this.config.shouldHandle(savedChange);
+      if (!accept) return;
+    }
+
     const checkpointId = this.projection.getCheckpointId(savedChange);
     const key = checkpointId.serialize();
 
@@ -323,7 +334,7 @@ export class FirestoreProjector {
   }
 
   // @Trace("projector.attempt")
-  private async attempt(
+  async attempt(
     source: ProjectedStream,
     checkpointId: CheckpointId,
     target: Cursor,
@@ -390,7 +401,7 @@ export class FirestoreProjector {
   }
 
   // @Trace("projector.queue.head")
-  private async getQueueHead(checkpointId: CheckpointId) {
+  async getQueueHead(checkpointId: CheckpointId) {
     return await this.queue.head(checkpointId);
   }
 
@@ -408,7 +419,7 @@ export class FirestoreProjector {
   }
 
   // @Trace("projector.enqueue")
-  private async enqueue(
+  async enqueue(
     source: ProjectedStream,
     head: Cursor | undefined,
     checkpointId: CheckpointId,
@@ -448,7 +459,7 @@ export class FirestoreProjector {
     return result;
   }
 
-  private async enqueueOne(checkpointId: CheckpointId, target: Cursor) {
+  async enqueueOne(checkpointId: CheckpointId, target: Cursor) {
     const event = await this.reader.get(target);
     if (!event) {
       throw new Error(`Event not found for cursor ${target.ref}`);
@@ -464,6 +475,130 @@ export class FirestoreProjector {
     }
 
     return result;
+  }
+
+  /**
+   * Enqueue all source events between the current queue head (exclusive)
+   * and `until` (inclusive). Defaults to Cursor.MAX, i.e. "to the end of
+   * the stream".
+   */
+  async enqueueUpTo(checkpointId: CheckpointId, until: Cursor = Cursor.MAX) {
+    const source = this.projection.getSource();
+    const head = await this.getQueueHead(checkpointId);
+    return this.enqueue(source, head, checkpointId, until);
+  }
+
+  /**
+   * Enqueue a single event by cursor. With `idempotent: true`, deletes any
+   * existing queued doc with the same eventId before re-creating, so a
+   * re-trigger after a partial replay doesn't fail with ALREADY_EXISTS.
+   */
+  async enqueueCursor(
+    checkpointId: CheckpointId,
+    cursor: Cursor,
+    opts: { idempotent?: boolean } = {},
+  ) {
+    if (opts.idempotent) {
+      await this.queue.queued(checkpointId, cursor.eventId).delete();
+    }
+    return this.enqueueOne(checkpointId, cursor);
+  }
+
+  /**
+   * Drain the queue to completion: repeatedly call attempt() with the
+   * current head as target until no unprocessed tasks remain. Yields to
+   * the event loop between iterations.
+   */
+  async dequeue(checkpointId: CheckpointId) {
+    const source = this.projection.getSource();
+    while (await this.queue.hasUnprocessed(checkpointId)) {
+      const head = await this.getQueueHead(checkpointId);
+      if (!head) return;
+      await this.attempt(source, checkpointId, head);
+      await wait(10);
+    }
+  }
+
+  /**
+   * Enqueue + drain in a loop until both phases are quiet. New events
+   * arriving mid-drain are picked up by the next enqueueUpTo cycle.
+   */
+  async catchup(
+    checkpointId: CheckpointId,
+    opts: { deadlineMs?: number } = {},
+  ) {
+    const deadline = opts.deadlineMs
+      ? Date.now() + opts.deadlineMs
+      : undefined;
+
+    while (true) {
+      await this.enqueueUpTo(checkpointId);
+      if (!(await this.queue.hasUnprocessed(checkpointId))) return;
+      await this.dequeue(checkpointId);
+      if (deadline !== undefined && Date.now() > deadline) {
+        throw new Error(
+          `catchup: deadline of ${opts.deadlineMs}ms exceeded for checkpoint ${checkpointId.serialize()}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Replay a checkpoint. Blocks the queue head, wipes existing tasks
+   * (except the blocker), seeds the start cursor, unblocks, and runs
+   * catchup forward. Concurrent listen() calls are safe — events
+   * arriving mid-replay are coalesced or re-enqueued by catchup.
+   *
+   * Provide either `from` (a Cursor) or `fromDate` (a wall-clock Date).
+   * If neither is given, replays from the first event in the stream.
+   */
+  async play(
+    checkpointId: CheckpointId,
+    opts: { from?: Cursor; fromDate?: Date } = {},
+  ) {
+    const start = await this.resolvePlayStart(checkpointId, opts);
+    if (!start) {
+      throw new Error(
+        `play: no events found for checkpoint ${checkpointId.serialize()}`,
+      );
+    }
+
+    await this.queue.block(checkpointId);
+    try {
+      await this.queue.flush(checkpointId, {
+        except: [FirestoreQueueStore.BLOCKER_EVENT_ID],
+      });
+      await this.enqueueCursor(checkpointId, start, { idempotent: true });
+    } finally {
+      await this.queue.unblock(checkpointId);
+    }
+
+    await this.catchup(checkpointId);
+  }
+
+  async playFrom(checkpointId: CheckpointId, fromDate: Date) {
+    return this.play(checkpointId, { fromDate });
+  }
+
+  private async resolvePlayStart(
+    checkpointId: CheckpointId,
+    opts: { from?: Cursor; fromDate?: Date },
+  ): Promise<Cursor | undefined> {
+    if (opts.from) return opts.from;
+
+    const source = this.projection.getSource();
+    const shard = checkpointId.shard();
+
+    if (opts.fromDate) {
+      const fromMicros = MicrosecondTimestamp.deserialize(opts.fromDate);
+      const fact = await this.reader.firstAtOrAfter(source, shard, fromMicros);
+      if (!fact) return undefined;
+      return Cursor.from(fact);
+    }
+
+    const fact = await this.reader.first(source, shard);
+    if (!fact) return undefined;
+    return Cursor.from(fact);
   }
 
   // @Trace("projector.queue.isProcessed")
@@ -591,6 +726,11 @@ export class AlreadyEnqueuedError extends Error {
 export class FirestoreQueueStore {
   converter = new DefaultConverter();
   collection: FirebaseFirestore.CollectionReference;
+
+  // Canonical blocker eventId used by block()/unblock() to park a sentinel
+  // task at Cursor.MAX. Stable across calls so unblock() can find it
+  // without the caller tracking the id.
+  static readonly BLOCKER_EVENT_ID = new EventId("_blocker_");
 
   constructor(public db: Firestore) {
     this.collection = db.collection(
@@ -919,11 +1059,62 @@ export class FirestoreQueueStore {
     await batch.commit();
   }
 
-  async flush(id: CheckpointId) {
+  async flush(id: CheckpointId, opts: { except?: EventId[] } = {}) {
+    const exclude = new Set((opts.except ?? []).map((e) => e.serialize()));
     const stream = this.queue(id).stream() as AsyncIterable<any>;
     const writer = this.collection.firestore.bulkWriter();
-    for await (const queued of stream) writer.delete(queued.ref);
+    for await (const queued of stream) {
+      if (exclude.has(queued.id)) continue;
+      writer.delete(queued.ref);
+    }
     await writer.close();
+  }
+
+  async hasUnprocessed(checkpointId: CheckpointId): Promise<boolean> {
+    const snap = await this.queue(checkpointId)
+      .where("processed", "==", false)
+      .where("remaining", ">", 0)
+      .limit(1)
+      .get();
+    return !snap.empty;
+  }
+
+  async block(
+    checkpointId: CheckpointId,
+    blockerId: EventId = FirestoreQueueStore.BLOCKER_EVENT_ID,
+  ) {
+    const task = new Task<false>({
+      id: blockerId,
+      ref: Cursor.MAX.ref,
+      occurredAt: Cursor.MAX.occurredAt,
+      revision: Cursor.MAX.revision,
+      attempts: 0,
+      processed: true,
+      /** @deprecated */ claimer: undefined,
+      /** @deprecated */ claimedAt: undefined,
+      claimsMetadata: {},
+      claimIds: [],
+      lock: new Lock({}),
+      remaining: 1,
+      claimTimeout: 0,
+      skipAfter: 0,
+      isolateAfter: 0,
+      lastUpdateTime: undefined,
+    });
+    await this.queued(checkpointId, blockerId).delete();
+    const serialized = task.serialize();
+    const converted = this.converter.toFirestore(serialized);
+    await this.queued(checkpointId, blockerId).create({
+      ...converted,
+      ref: Cursor.MAX.ref,
+    });
+  }
+
+  async unblock(
+    checkpointId: CheckpointId,
+    blockerId: EventId = FirestoreQueueStore.BLOCKER_EVENT_ID,
+  ) {
+    await this.queued(checkpointId, blockerId).delete();
   }
 
   /**

--- a/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
+++ b/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
@@ -612,8 +612,8 @@ export class FirestoreQueueStore {
     for (const task of tasks) {
       const ref = this.queued(checkpointId, task.id);
       batch.create(ref, {
-        ref: this.db.doc(task.cursor.ref),
         ...this.converter.toFirestore(task.serialize()),
+        ref: task.cursor.ref,
       });
     }
 
@@ -665,6 +665,7 @@ export class FirestoreQueueStore {
     const head = this.queue(checkpointId)
       .orderBy("occurredAt", "desc")
       .orderBy("revision", "desc")
+      .orderBy("ref", "desc")
       .limit(1);
     const headDoc = (await head.get()).docs[0];
     if (!headDoc) {
@@ -692,6 +693,7 @@ export class FirestoreQueueStore {
       .where("remaining", ">", 0)
       .orderBy("occurredAt", "asc")
       .orderBy("revision", "asc")
+      .orderBy("ref", "asc")
       .limit(100);
 
     const snapshot = await query.get();
@@ -744,7 +746,8 @@ export class FirestoreQueueStore {
     const query = this.queue(checkpointId)
       .where("claimIds", "array-contains", claimer.serialize())
       .orderBy("occurredAt", "asc")
-      .orderBy("revision", "asc");
+      .orderBy("revision", "asc")
+      .orderBy("ref", "asc");
 
     const snapshot = await query.get();
     return snapshot.docs
@@ -852,6 +855,7 @@ export class FirestoreQueueStore {
       .where("remaining", ">", 0)
       .orderBy("occurredAt", "asc")
       .orderBy("revision", "asc")
+      .orderBy("ref", "asc")
       .limit(1);
     const tailDoc = (await tail.get()).docs[0];
     if (!tailDoc) {
@@ -882,7 +886,8 @@ export class FirestoreQueueStore {
       .where("remaining", ">", 0)
       .where("occurredAt", "<", aMonthAgo.serialize()) // Only consider events older than 4 weeks
       .orderBy("occurredAt", "asc")
-      .orderBy("revision", "asc");
+      .orderBy("revision", "asc")
+      .orderBy("ref", "asc");
 
     const MIN_TRAIL = 1; // Keep at least one processed document to maintain the tail cursor
     const TRAIL = MIN_TRAIL + 0; // Extra buffer to optimize isProcessed checks

--- a/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
+++ b/packages/event-sourcing-firestore/src/projection/firestore.projector.ts
@@ -64,6 +64,15 @@ interface FirestoreProjectorConfig {
   enqueue: {
     batchSize: number;
   };
+  /**
+   * Controls retention of processed queue tasks.
+   *
+   * - `false` (default): never delete processed tasks. Preserves the queue
+   *   as a durable audit trail for replay diagnostics.
+   * - `{ olderThan }`: delete processed tasks older than `olderThan` after
+   *   each successful event handling.
+   */
+  cleanup?: false | { olderThan: MicrosecondTimestamp };
   logger?: ProjectorLogger;
   /** @deprecated Use `logger.error` instead */
   onProcessError: (error: Error) => void;
@@ -285,7 +294,9 @@ export class FirestoreProjector {
       }
 
       if (status === Status.SUCCESS) {
-        await this.queue.cleanup(checkpointId);
+        if (this.config.cleanup) {
+          await this.queue.cleanup(checkpointId, this.config.cleanup.olderThan);
+        }
         const durationMs = Date.now() - startedAt;
         this.logger.info(
           `processed: Checkpoint<${checkpointKey}> caught up to Event<${eventId}> in ${durationMs}ms`,
@@ -877,14 +888,15 @@ export class FirestoreQueueStore {
     return tailCursor;
   }
 
-  async cleanup(id: CheckpointId) {
-    const aMonthAgo = MicrosecondTimestamp.now().sub(
-      MicrosecondTimestamp.WEEK.mult(4),
-    );
+  async cleanup(
+    id: CheckpointId,
+    olderThan: MicrosecondTimestamp = MicrosecondTimestamp.WEEK.mult(4),
+  ) {
+    const threshold = MicrosecondTimestamp.now().sub(olderThan);
 
     const query = this.queue(id)
       .where("remaining", ">", 0)
-      .where("occurredAt", "<", aMonthAgo.serialize()) // Only consider events older than 4 weeks
+      .where("occurredAt", "<", threshold.serialize())
       .orderBy("occurredAt", "asc")
       .orderBy("revision", "asc")
       .orderBy("ref", "asc");

--- a/packages/shape/src/deserialization-error.spec.ts
+++ b/packages/shape/src/deserialization-error.spec.ts
@@ -1,0 +1,59 @@
+import { Shape } from "./_";
+import { DeserializationError } from "./deserialization-error";
+
+class Latitude extends Shape(Number) {
+  static override deserialize(value: any): Latitude {
+    if (typeof value !== "number") {
+      throw new DeserializationError("Expected number", {
+        rejectedValue: value,
+        expected: "number",
+      });
+    }
+    return new Latitude(value);
+  }
+}
+
+class Address extends Shape({ latitude: Latitude }) {}
+class User extends Shape({ address: Address }) {}
+class Payload extends Shape({ user: User }) {}
+
+describe("DeserializationError", () => {
+  it("collects nested path on dict failure", () => {
+    let caught: DeserializationError | undefined;
+    try {
+      Payload.deserialize({
+        user: { address: { latitude: "not-a-number" as any } },
+      } as any);
+    } catch (err) {
+      caught = err as DeserializationError;
+    }
+
+    expect(caught).toBeInstanceOf(DeserializationError);
+    expect(caught!.path).toEqual(["user", "address", "latitude"]);
+    expect(caught!.rejectedValue).toBe("not-a-number");
+    expect(caught!.expected).toBe("number");
+    expect(caught!.message).toContain("/user/address/latitude");
+  });
+
+  it("includes index segment for arrays", () => {
+    class Latitudes extends Shape([Latitude]) {}
+
+    let caught: DeserializationError | undefined;
+    try {
+      Latitudes.deserialize([1, 2, "bad" as any]);
+    } catch (err) {
+      caught = err as DeserializationError;
+    }
+
+    expect(caught).toBeInstanceOf(DeserializationError);
+    expect(caught!.path).toEqual(["2"]);
+    expect(caught!.rejectedValue).toBe("bad");
+  });
+
+  it("wrap() promotes plain errors and prepends segment", () => {
+    const wrapped = DeserializationError.wrap(new Error("boom"), "field", 42);
+    expect(wrapped.path).toEqual(["field"]);
+    expect(wrapped.rejectedValue).toBe(42);
+    expect(wrapped.message).toContain("boom");
+  });
+});

--- a/packages/shape/src/deserialization-error.spec.ts
+++ b/packages/shape/src/deserialization-error.spec.ts
@@ -2,14 +2,14 @@ import { Shape } from "./_";
 import { DeserializationError } from "./deserialization-error";
 
 class Latitude extends Shape(Number) {
-  static override deserialize(value: any): Latitude {
+  static override deserialize(value: number) {
     if (typeof value !== "number") {
       throw new DeserializationError("Expected number", {
         rejectedValue: value,
         expected: "number",
       });
     }
-    return new Latitude(value);
+    return super.deserialize(value);
   }
 }
 

--- a/packages/shape/src/deserialization-error.ts
+++ b/packages/shape/src/deserialization-error.ts
@@ -1,0 +1,68 @@
+export type DeserializationErrorContext = {
+  expected?: string;
+  rejectedValue?: unknown;
+  registryEntry?: { name: string; version?: number };
+};
+
+export class DeserializationError extends Error {
+  readonly path: string[];
+  readonly rejectedValue: unknown;
+  readonly expected?: string;
+  registryEntry?: { name: string; version?: number };
+  override readonly cause?: unknown;
+
+  constructor(
+    message: string,
+    options: {
+      path?: string[];
+      rejectedValue?: unknown;
+      expected?: string;
+      registryEntry?: { name: string; version?: number };
+      cause?: unknown;
+    } = {},
+  ) {
+    const { path = [], rejectedValue, expected, registryEntry, cause } = options;
+    const formattedPath = path.length ? `/${path.join("/")}` : "";
+    super(
+      `${message}${formattedPath ? ` (at ${formattedPath})` : ""}`,
+    );
+    this.name = "DeserializationError";
+    this.path = path;
+    this.rejectedValue = rejectedValue;
+    this.expected = expected;
+    this.registryEntry = registryEntry;
+    this.cause = cause;
+  }
+
+  prependPath(segment: string): DeserializationError {
+    return new DeserializationError(this.unprefixedMessage(), {
+      path: [segment, ...this.path],
+      rejectedValue: this.rejectedValue,
+      expected: this.expected,
+      registryEntry: this.registryEntry,
+      cause: this.cause ?? this,
+    });
+  }
+
+  private unprefixedMessage(): string {
+    const idx = this.message.lastIndexOf(" (at /");
+    return idx >= 0 ? this.message.slice(0, idx) : this.message;
+  }
+
+  static wrap(
+    error: unknown,
+    segment: string,
+    rejectedValue?: unknown,
+  ): DeserializationError {
+    if (error instanceof DeserializationError) {
+      return error.prependPath(segment);
+    }
+    const cause = error instanceof Error ? error : undefined;
+    const message = cause?.message ?? String(error);
+    return new DeserializationError(message, {
+      path: [segment],
+      rejectedValue,
+      cause: cause ?? error,
+    });
+  }
+}

--- a/packages/shape/src/dict.ts
+++ b/packages/shape/src/dict.ts
@@ -7,6 +7,7 @@ import {
   type Constructor,
   Empty,
 } from "./_";
+import { DeserializationError } from "./deserialization-error";
 
 export type DictShorthand = { [key: string]: Shorthand };
 
@@ -55,8 +56,12 @@ export const Dict = <
       const split = Object.entries(of);
       const transform = split.map(([key, child]) => {
         const longhand = Shape(child) as any;
-        const deserialized = longhand.$deserialize((value as any)[key]);
-        return [key, deserialized];
+        try {
+          const deserialized = longhand.$deserialize((value as any)?.[key]);
+          return [key, deserialized];
+        } catch (err) {
+          throw DeserializationError.wrap(err, key, (value as any)?.[key]);
+        }
       });
       const merge = Object.fromEntries(transform);
       return merge;

--- a/packages/shape/src/index.ts
+++ b/packages/shape/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./_";
+export * from "./deserialization-error";
 export * from "./choice";
 export * from "./class";
 export * from "./dict";

--- a/packages/shape/src/multiple.ts
+++ b/packages/shape/src/multiple.ts
@@ -8,6 +8,7 @@ import {
   Empty,
   type Constructor,
 } from "./_";
+import { DeserializationError } from "./deserialization-error";
 
 export type MultipleConfiguration = Definition | Shorthand;
 export type MultipleShorthand = [any] | readonly [any];
@@ -41,7 +42,14 @@ export const Multiple = <
     }
 
     static $deserialize(value: any) {
-      return (value as any).map(longhand.$deserialize);
+      const deserialize = (longhand as any).$deserialize as (v: any) => any;
+      return (value as any).map((item: any, index: number) => {
+        try {
+          return deserialize(item);
+        } catch (err) {
+          throw DeserializationError.wrap(err, String(index), item);
+        }
+      });
     }
 
     static $serialize(value: any) {

--- a/packages/store-firestore/src/firestore.transaction.ts
+++ b/packages/store-firestore/src/firestore.transaction.ts
@@ -12,11 +12,31 @@ export class FirestoreTransaction implements Transaction {
   commitListeners: CommitListener[] = [];
   constructor(public readonly transaction: FirebaseTransaction) {}
 
-  counter = -1;
-
+  // Returns a value used as the event `revision`, intended as a tiebreaker
+  // when multiple events share the same `serverTimestamp()` microsecond.
+  //
+  // We use `process.hrtime.bigint()` (nanoseconds since process start) rather
+  // than a per-transaction counter so that two concurrent transactions in
+  // the same process produce distinct revisions and don't collide on
+  // `(occurredAt, revision)`.
+  //
+  // Known limitations of this approach (see ddd-ts-prototype-overrides.md):
+  // - Across processes/replicas: two processes can return the same value
+  //   in the same nanosecond. Cross-replica ties are still possible (just
+  //   rarer than the previous counter-based default).
+  // - Cold starts: hrtime resets per process, so a freshly booted process's
+  //   revisions are *lower* than an older process's tail. `revision` is not
+  //   monotonic across the deployment.
+  // - `Number()` cast: hrtime is a bigint of nanoseconds since process
+  //   start. Exceeds Number.MAX_SAFE_INTEGER after ~104 days of uptime;
+  //   acceptable for typical lifetimes, not safe long-term.
+  //
+  // The downstream cursor/queue layers handle ties correctly via document-id
+  // tiebreak, so this is a probability reduction, not a correctness fix.
+  // A pluggable revision strategy is the right long-term answer; this is the
+  // safer default until that lands.
   increment() {
-    this.counter++;
-    return this.counter;
+    return Number(process.hrtime.bigint());
   }
 
   onCommit(callback: CommitListener) {


### PR DESCRIPTION
…ojector

Three compounding bugs caused the projector to get stuck (or skip events) when multiple source events shared (occurredAt, revision):

1. slice/read ordered by (occurredAt, revision) only — startAfter could not resume mid-tie. Added FieldPath.documentId() as third order key with 3-value startAfter/endAt.
2. FirestoreQueueStore.{head,unprocessed,claimed,getTailCursor,cleanup} ordered by 2 fields only; head returned an arbitrary doc within a tie group, misrouting target.isAfter(head). Added ref tiebreak in matching direction.
3. enqueue wrote ref as DocumentReference; DefaultConverter mangled it to {_firestore,_path,_converter} on read; Cursor.isAfter then compared a string against "[object Object]". Now writes ref as string (overrides any converter output via spread ordering). Cursor.isAfter throws on non-string ref to surface future regressions.

Adds an end-to-end regression spec that drives the projector with tied events and asserts convergence; without these fixes it stalls with "No unprocessed tasks found".